### PR TITLE
Fix: Normalize CORS_ORIGINS environment variable and add flexible Pydantic validation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -32,7 +32,7 @@ AZURE_KEY_VAULT_URL=https://your-keyvault.vault.azure.net/
 # Application settings
 ENVIRONMENT=development
 LOG_LEVEL=INFO
-CORS_ORIGINS=http://localhost:5173,http://localhost:3000
+CORS_ORIGINS=["http://localhost:5173","http://localhost:3000"]
 # When set to true, /api/analyze-diagram returns a canned analysis for frontend/local development
 DEV_ANALYZE_BYPASS=false
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,7 @@
 """Configuration settings for the Azure Architect Backend."""
 
 from typing import Any, List
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -49,10 +49,21 @@ class Settings(BaseSettings):
     # Application settings
     ENVIRONMENT: str = Field(default="development", description="Environment name")
     LOG_LEVEL: str = Field(default="INFO", description="Logging level")
-    CORS_ORIGINS: List[str] = Field(
-        default=["http://localhost:5173", "http://localhost:3000"],
-        description="CORS allowed origins"
+    CORS_ORIGINS: str | List[str] = Field(
+        default="http://localhost:5173,http://localhost:3000",
+        description="CORS allowed origins (comma-separated or JSON array)"
     )
+    
+    @field_validator('CORS_ORIGINS', mode='before')
+    @classmethod
+    def parse_cors_origins(cls, v: Any) -> List[str]:
+        """Parse CORS_ORIGINS from comma-separated string or list."""
+        if isinstance(v, str):
+            # Split by comma and strip whitespace
+            return [origin.strip() for origin in v.split(',') if origin.strip()]
+        elif isinstance(v, list):
+            return v
+        return ["http://localhost:5173", "http://localhost:3000"]
     
     # Chat and WebSocket
     CHAT_MAX_HISTORY: int = Field(default=50, description="Max chat history messages")


### PR DESCRIPTION
This PR fixes an issue where the `CORS_ORIGINS` environment variable caused errors due to a mismatch between the format provided and what Pydantic expected.

### 🔧 What was happening

The application expected `CORS_ORIGINS` to be a `List[str]`, but users were often providing it as a simple string, resulting in validation errors.

### ✅ What this PR implements

* Updated the `.env.example` file to use the correct list format.
* Modified the Pydantic model to accept **both**:

  * comma-separated strings
  * JSON list format
* Added a custom `@field_validator` to normalize the input.
* Added safe fallback default values if no valid format is provided.

### 📌 New behavior

The application now supports:

* `http://localhost:5173,http://localhost:3000`
* `["http://localhost:5173", "http://localhost:3000"]`
* Auto-trim of whitespace
* Default values if needed

This improves the developer experience, reduces configuration errors, and makes the project more beginner-friendly for the community.
